### PR TITLE
Feature/cfsr 0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ endif()
 
 # NetCDF
 set( NETCDF_F90 ON CACHE BOOL "Compile with Fortran NetCDF" )
-find_package( NetCDF REQUIRED )
-include_directories( ${NETCDF_INCLUDE_DIR} )
+find_package( NetCDF REQUIRED COMPONENTS Fortran )
+include_directories( ${NETCDF_INCLUDE_DIRS} )
 
 # fms
 

--- a/cicecore/cicedynB/analysis/ice_diagnostics.F90
+++ b/cicecore/cicedynB/analysis/ice_diagnostics.F90
@@ -971,9 +971,10 @@
                                                        psnoice(2)
         write(nu_diag,900) 'snow change (m)        = ',pdsnow(1), &
                                                        pdsnow(2)
-        write(nu_diag,900) 'effective dhi (m)      = ',pdhi(1),pdhi(2)
-        write(nu_diag,900) 'effective dhs (m)      = ',pdhs(1),pdhs(2)
-        write(nu_diag,900) 'intnl enrgy chng(W/m^2)= ',pde (1),pde (2)
+!jk Different resolutions seems to show NANvalues -----------------------
+!jk        write(nu_diag,900) 'effective dhi (m)      = ',pdhi(1),pdhi(2)
+!jk        write(nu_diag,900) 'effective dhs (m)      = ',pdhs(1),pdhs(2)
+!jk        write(nu_diag,900) 'intnl enrgy chng(W/m^2)= ',pde (1),pde (2)
         write(nu_diag,*) '----------ocn----------'
         write(nu_diag,900) 'sst (C)                = ',psst(1),psst(2)
         write(nu_diag,900) 'sss (ppt)              = ',psss(1),psss(2)

--- a/cicecore/cicedynB/general/ice_step_mod.F90
+++ b/cicecore/cicedynB/general/ice_step_mod.F90
@@ -283,7 +283,8 @@
             enddo
          endif ! tr_aero
 
-         if (tmask(i,j,iblk)) &
+!jk Added more if-condition options to avoid blowup issues at therm1 call--------
+         if (tmask(i,j,iblk).and.rhoa(i,j,iblk).ne.0..and.potT(i,j,iblk).ne.0.) &
          call icepack_step_therm1(dt, ncat, nilyr, nslyr, n_aero,                &
                             aicen_init  (i,j,:,iblk),                           &
                             vicen_init  (i,j,:,iblk), vsnon_init  (i,j,:,iblk), &

--- a/cmake/cice6_compiler_flags.cmake
+++ b/cmake/cice6_compiler_flags.cmake
@@ -2,15 +2,9 @@
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-set(TAU_FLAG "$ENV{TAU_LIBS}")
-if(TAU_FLAG)
-    set(TAU_CPP "-Duse_TAU")
-else()
-    set(TAU_CPP "")
-endif()
 
 #add_definitions ( -Duse_libMPI -Duse_netCDF -DSPMD -DNXGLOB=4)
-add_definitions ( -Duse_libMPI -Duse_netCDF -Dncdf -Dgather_scatter_barrier ${TAU_CPP})
+add_definitions ( -Duse_libMPI -Duse_netCDF -Dncdf -Dgather_scatter_barrier)
 
 #######################################################################################
 # Fortran

--- a/cmake/compiler_flags_Intel_Fortran.cmake
+++ b/cmake/compiler_flags_Intel_Fortran.cmake
@@ -7,7 +7,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback -msse2" )
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -convert big_endian -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback -msse2" )
 
 ####################################################################
 # RELEASE FLAGS


### PR DESCRIPTION
1, Update of compilation flags/cleanup and netcdf package name.
2. added an ad-hoc condition to avoid blowup situation (therm1 call) with cfsr-based high resolution problem set. More systematic control will be implemented when merged with cice6.1.
3. tested with cfsr 1/2-degree problem set on hera.
